### PR TITLE
Replaced "Maruku" with "Markdown" as Awestruct uses RDiscount now

### DIFF
--- a/file_types.md
+++ b/file_types.md
@@ -42,13 +42,13 @@ To produce a file `index.html`, the Haml source file should be
 named `index.html.haml`.  This allows for non-HTML generation,
 such as for XML or other file types.
 
-### Maruku (`.md`)
+### Markdown (`.md`)
 
-Maruku files are interpreted anywhere within the site tree.
+Markdown files are interpreted anywhere within the site tree.
 
 The `.md` extension will be replaced by `.html` by default.
 
-The engine will interpolate the Maruku source as a typical
+The engine will interpolate the Markdown source as a typical
 Ruby `String`, allowing for expressions such as
 
     # This is the \#{page.title}


### PR DESCRIPTION
I saw that the site still talks about "Maruku" files although Maruku has been replaced with RDiscount e409d36e02ccf59eb90b2f999512f6ae0a635133
