### PR TITLE
Fix latest-news template example to not break formatting of pre tags

### DIFF
--- a/extensions/posts/usage.md
+++ b/extensions/posts/usage.md
@@ -54,6 +54,6 @@ To create a "latest news" type of page, you could have a template such as
         %h2 
           = post.date.strftime( '%d %B %Y' )
         .content
-          = post.content
+          ~ post.content
 
 


### PR DESCRIPTION
The current example is confusing as it breaks markdown code blocks formatting. We should not leave this as an exercise for the reader to figure it out, even if it only took me 30 minutes as I'm not that familiar with haml :)
