### PR TITLE
Use bootstrap 2.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'rb-inotify', '~> 0.9.0', :platforms => [:ruby, :jruby]
 gem 'yard', '~> 0.8.7.1'
 gem 'rake', '~> 10.0.0'
 
+# force to quse bootstrap 2.3.x and not a newer version because of incompatibility issues
+gem 'bootstrap-sass', '~> 2.3.2'
+
 # required if you want to use the minify extension
 gem 'htmlcompressor', '~> 0.0.5'
 gem 'coffee-script', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,20 @@
 GIT
   remote: git://github.com/awestruct/awestruct.git
-  revision: 66d3b3cccaf734bbdbe07c97e650e90c8f28a5ba
+  revision: 4f94e05b0b35bcf618e17d9b1bd240978fa1f695
   specs:
-    awestruct (0.5.4.dev)
+    awestruct (0.5.4.rc3)
       bootstrap-sass (>= 2.3.1.0)
       compass (>= 0.12.1)
       compass-960-plugin (~> 0.10.4)
       haml (~> 4.0.1)
-      listen (>= 0.7.3)
+      listen (~> 1.0)
+      mime-types (= 1.25)
       nokogiri (= 1.5.10)
       rack (~> 1.5.2)
       rest-client (>= 1.6.7)
       ruby-s3cmd (~> 0.1.5)
-      tilt (>= 1.3.6)
-      zurb-foundation (>= 4.0.9)
+      tilt (>= 1.3.5, < 2.0)
+      zurb-foundation (>= 4.0.9, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -25,7 +26,7 @@ GEM
     asciidoctor (0.1.4)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
-    chunky_png (1.2.8)
+    chunky_png (1.2.9)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
@@ -37,22 +38,22 @@ GEM
     compass-960-plugin (0.10.4)
       compass (>= 0.10.0)
     erubis (2.7.0)
-    execjs (2.0.1)
-    ffi (1.9.0)
+    execjs (2.0.2)
+    ffi (1.9.3)
     fssm (0.2.10)
     git (1.2.6)
-    haml (4.0.3)
+    haml (4.0.4)
       tilt
     htmlcompressor (0.0.7)
       yui-compressor (~> 0.9.6)
-    json (1.8.0)
+    json (1.8.1)
     libv8 (3.11.8.17)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     mime-types (1.25)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     nokogiri (1.5.10)
     open4 (1.3.0)
     rack (1.5.2)
@@ -69,7 +70,7 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     ruby-s3cmd (0.1.5)
-    sass (3.2.11)
+    sass (3.2.12)
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
@@ -77,7 +78,7 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    yard (0.8.7.1)
+    yard (0.8.7.3)
     yui-compressor (0.9.6)
       POpen4 (>= 0.1.4)
     zurb-foundation (4.3.2)
@@ -89,6 +90,7 @@ PLATFORMS
 DEPENDENCIES
   asciidoctor (~> 0.1.4)
   awestruct!
+  bootstrap-sass (~> 2.3.2)
   coffee-script (~> 2.2)
   erubis (~> 2.7.0)
   git (~> 1.2.6)


### PR DESCRIPTION
Bootstrap 3.x has compatibility issues with previous versions, which breaks the
build of the styles.css file.
