### PR TITLE
Adding a small section to document to .awestruct_ignore file

### DIFF
--- a/file_types.md
+++ b/file_types.md
@@ -117,6 +117,11 @@ rewrite rules.
 For this reason, *Awestruct* will include `.htaccess` access files
 when generating the output tree.
 
+### Exclusions
+
+*Awestruct* will ignore any file or folder listed in the optional `.awestruct_ignore` file located at the root of the project.
+
+
 ### Everything else (`*.*`)
 
 Any unrecognized file will simply be copied over to the output tree.


### PR DESCRIPTION
This optional file is used to ignore some regular files or folders during the websote build.
