### PR TITLE
Example .awestruct_ignore file was missing 'vendor' directory exclusion ...

### DIFF
--- a/auto-deploy-to-github-pages.adoc
+++ b/auto-deploy-to-github-pages.adoc
@@ -62,6 +62,7 @@ Let's add the names of those files to Awestruct's ignore file, +.awestruct_ignor
  Gemfile
  Gemfile.lock
  Rakefile
+ vendor
  LINES
 
 Since you're deploying to GitHub Pages, you should be aware that Jekyll normally run on the files on the publish branch.


### PR DESCRIPTION
...in which gems are locally installed during Travis-CI builds. Missing this exclusion can cause build issues.
