### PR TITLE
Updating link to API documentation

### DIFF
--- a/_layouts/base.html.haml
+++ b/_layouts/base.html.haml
@@ -95,7 +95,7 @@
               %li 
                 %a{:href=>"#{site.base_url}/source/"} Source Code
               %li 
-                %a{:href=>"#{site.base_url}/yardoc/"} API Documentation
+                %a{:href=>"http://www.rubydoc.info/gems/awestruct/"} API Documentation
               %li 
                 %a{:href=>'mailto:talk-subscribe@awestruct.org?subject=subscribe'} Mailing List
               %li


### PR DESCRIPTION
Pointing to rubydoc.info, if that's fine for everyone.